### PR TITLE
Add cropType property that allows round cropper

### DIFF
--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -13,6 +13,7 @@ class App extends React.Component {
     crop: { x: 0, y: 0 },
     zoom: 1,
     aspect: 4 / 3,
+    cropArea: { shape: 'square', showGrid: true },
   }
 
   onCropChange = crop => {
@@ -39,6 +40,7 @@ class App extends React.Component {
             onCropChange={this.onCropChange}
             onCropComplete={this.onCropComplete}
             onZoomChange={this.onZoomChange}
+            cropArea={this.state.cropArea}
           />
         </div>
       </div>

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -13,7 +13,7 @@ class App extends React.Component {
     crop: { x: 0, y: 0 },
     zoom: 1,
     aspect: 4 / 3,
-    cropShape: 'square',
+    cropShape: 'rect',
     showGrid: true,
   }
 

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -13,7 +13,8 @@ class App extends React.Component {
     crop: { x: 0, y: 0 },
     zoom: 1,
     aspect: 4 / 3,
-    cropArea: { shape: 'square', showGrid: true },
+    cropShape: 'square',
+    showGrid: true,
   }
 
   onCropChange = crop => {
@@ -37,10 +38,11 @@ class App extends React.Component {
             crop={this.state.crop}
             zoom={this.state.zoom}
             aspect={this.state.aspect}
+            cropShape={this.state.cropShape}
+            showGrid={this.state.showGrid}
             onCropChange={this.onCropChange}
             onCropComplete={this.onCropComplete}
             onZoomChange={this.onZoomChange}
-            cropArea={this.state.cropArea}
           />
         </div>
       </div>

--- a/src/index.js
+++ b/src/index.js
@@ -287,6 +287,7 @@ Cropper.defaultProps = {
   aspect: 4 / 3,
   maxZoom: MAX_ZOOM,
   minZoom: MIN_ZOOM,
+  cropShape: 'rect',
   showGrid: true,
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import {
   computeCroppedArea,
   getCenter,
 } from './helpers'
-import { Container, Img, createCropArea } from './styles'
+import { Container, Img, CropArea } from './styles'
 
 const MIN_ZOOM = 1
 const MAX_ZOOM = 3
@@ -249,8 +249,6 @@ class Cropper extends React.Component {
       showGrid,
     } = this.props
 
-    const CropArea = createCropArea({ shape: cropShape, showGrid })
-
     return (
       <Container
         onMouseDown={this.onMouseDown}
@@ -270,6 +268,8 @@ class Cropper extends React.Component {
         />
         {this.state.cropSize && (
           <CropArea
+            cropShape={cropShape}
+            showGrid={showGrid}
             style={{
               width: this.state.cropSize.width,
               height: this.state.cropSize.height,

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import {
   computeCroppedArea,
   getCenter,
 } from './helpers'
-import { Container, Img, RectCropArea, RoundCropArea } from './styles'
+import { Container, Img, createCropArea } from './styles'
 
 const MIN_ZOOM = 1
 const MAX_ZOOM = 3
@@ -245,18 +245,10 @@ class Cropper extends React.Component {
     const {
       crop: { x, y },
       zoom,
-      cropType,
+      cropArea: { shape, showGrid },
     } = this.props
 
-    const CropArea = (() => {
-      switch (cropType) {
-        case 'round':
-          return RoundCropArea
-        case 'rect':
-        default:
-          return RectCropArea
-      }
-    })()
+    const CropArea = createCropArea({ shape, showGrid })
 
     return (
       <Container
@@ -294,6 +286,7 @@ Cropper.defaultProps = {
   aspect: 4 / 3,
   maxZoom: MAX_ZOOM,
   minZoom: MIN_ZOOM,
+  cropArea: { shape: 'rect', showGrid: true },
 }
 
 export default Cropper

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import {
   computeCroppedArea,
   getCenter,
 } from './helpers'
-import { Container, Img, CropArea } from './styles'
+import { Container, Img, RectCropArea, RoundCropArea } from './styles'
 
 const MIN_ZOOM = 1
 const MAX_ZOOM = 3
@@ -245,7 +245,19 @@ class Cropper extends React.Component {
     const {
       crop: { x, y },
       zoom,
+      cropType,
     } = this.props
+
+    const CropArea = (() => {
+      switch (cropType) {
+        case 'round':
+          return RoundCropArea
+        case 'rect':
+        default:
+          return RectCropArea
+      }
+    })()
+
     return (
       <Container
         onMouseDown={this.onMouseDown}

--- a/src/index.js
+++ b/src/index.js
@@ -245,10 +245,11 @@ class Cropper extends React.Component {
     const {
       crop: { x, y },
       zoom,
-      cropArea: { shape, showGrid },
+      cropShape,
+      showGrid,
     } = this.props
 
-    const CropArea = createCropArea({ shape, showGrid })
+    const CropArea = createCropArea({ shape: cropShape, showGrid })
 
     return (
       <Container
@@ -286,7 +287,7 @@ Cropper.defaultProps = {
   aspect: 4 / 3,
   maxZoom: MAX_ZOOM,
   minZoom: MIN_ZOOM,
-  cropArea: { shape: 'rect', showGrid: true },
+  showGrid: true,
 }
 
 export default Cropper

--- a/src/styles.js
+++ b/src/styles.js
@@ -32,8 +32,7 @@ const cropperLines = {
   position: 'absolute',
   border: lineBorder,
 }
-
-export const CropArea = styled('div')({
+const cropperArea = {
   position: 'absolute',
   left: '50%',
   top: '50%',
@@ -41,6 +40,10 @@ export const CropArea = styled('div')({
   border: lineBorder,
   boxSizing: 'border-box',
   boxShadow: '0 0 0 9999em rgba(0, 0, 0, 0.5)',
+}
+
+export const RectCropArea = styled('div')({
+  ...cropperArea,
   '&::before': {
     ...cropperLines,
     top: 0,
@@ -59,4 +62,9 @@ export const CropArea = styled('div')({
     borderLeft: 0,
     borderRight: 0,
   },
+})
+
+export const RoundCropArea = styled('div')({
+  ...cropperArea,
+  borderRadius: '50%',
 })

--- a/src/styles.js
+++ b/src/styles.js
@@ -66,16 +66,15 @@ const roundShape = {
   borderRadius: '50%',
 }
 
-export const createCropArea = ({ shape, showGrid }) =>
-  styled('div')({
-    ...(() => {
-      switch (shape) {
-        case 'round':
-          return { ...cropperArea, ...roundShape }
-        case 'rect':
-        default:
-          return cropperArea
-      }
-    })(),
-    ...(showGrid ? gridLines : {}),
-  })
+export const CropArea = styled('div')({}, ({ cropShape, showGrid }) => ({
+  ...(() => {
+    switch (cropShape) {
+      case 'round':
+        return { ...cropperArea, ...roundShape }
+      case 'rect':
+      default:
+        return cropperArea
+    }
+  })(),
+  ...(showGrid ? gridLines : {}),
+}))

--- a/src/styles.js
+++ b/src/styles.js
@@ -40,9 +40,9 @@ const cropperArea = {
   border: lineBorder,
   boxSizing: 'border-box',
   boxShadow: '0 0 0 9999em rgba(0, 0, 0, 0.5)',
+  overflow: 'hidden',
 }
-
-const thirds = {
+const gridLines = {
   '&::before': {
     ...cropperLines,
     top: 0,
@@ -62,15 +62,13 @@ const thirds = {
     borderRight: 0,
   },
 }
-
-export const RectCropArea = styled('div')({
-  ...cropperArea,
-  ...thirds,
-})
-
-export const RoundCropArea = styled('div')({
-  ...cropperArea,
+const roundShape = {
   borderRadius: '50%',
-  overflow: 'hidden',
-  ...thirds,
-})
+}
+
+export const createCropArea = ({ shape, showGrid }) =>
+  styled('div')({
+    ...cropperArea,
+    ...(shape === 'round' ? roundShape : {}),
+    ...(showGrid ? gridLines : {}),
+  })

--- a/src/styles.js
+++ b/src/styles.js
@@ -68,7 +68,14 @@ const roundShape = {
 
 export const createCropArea = ({ shape, showGrid }) =>
   styled('div')({
-    ...cropperArea,
-    ...(shape === 'round' ? roundShape : {}),
+    ...(() => {
+      switch (shape) {
+        case 'round':
+          return { ...cropperArea, ...roundShape }
+        case 'rect':
+        default:
+          return cropperArea
+      }
+    })(),
     ...(showGrid ? gridLines : {}),
   })

--- a/src/styles.js
+++ b/src/styles.js
@@ -42,8 +42,7 @@ const cropperArea = {
   boxShadow: '0 0 0 9999em rgba(0, 0, 0, 0.5)',
 }
 
-export const RectCropArea = styled('div')({
-  ...cropperArea,
+const thirds = {
   '&::before': {
     ...cropperLines,
     top: 0,
@@ -62,9 +61,16 @@ export const RectCropArea = styled('div')({
     borderLeft: 0,
     borderRight: 0,
   },
+}
+
+export const RectCropArea = styled('div')({
+  ...cropperArea,
+  ...thirds,
 })
 
 export const RoundCropArea = styled('div')({
   ...cropperArea,
   borderRadius: '50%',
+  overflow: 'hidden',
+  ...thirds,
 })


### PR DESCRIPTION
Add a new property to the Cropper component, **cropType**. The new property will allow to pass in different cropper styles: _round_, _rect_ for the current change.

My use case is that I need a round cropper to replace [Croppie](https://foliotek.github.io/Croppie/), react-easy-crop is perfect and really well implemented but it is missing this. Let me know if this is a feature you want to add and if yes if this is the interface you are looking for or you want some other changes.