### PR TITLE
Invert props order check on update

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,10 +39,10 @@ class Cropper extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.zoom !== this.props.zoom) {
-      this.recomputeCropPosition()
-    } else if (prevProps.aspect !== this.props.aspect) {
+    if (prevProps.aspect !== this.props.aspect) {
       this.computeSizes()
+    } else if (prevProps.zoom !== this.props.zoom) {
+      this.recomputeCropPosition()
     }
   }
 


### PR DESCRIPTION
This fixes an issue that prevents updating at the same time zoom and aspect ratio. Because `computeSizes` also recomputes crop position, if aspect ratio and/or zoom are changed, both values will be updated