### PR TITLE
Add zoomSpeed-prop and use it to multiply the wheelzoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ class App extends React.Component {
 | `maxZoom` | number | | maximum zoom of the image. Defaults to 3. |
 | `cropShape` | 'rect' \| 'round' | | Shape of the crop area. Defaults to 'rect'. |
 | `showGrid` | boolean | | Whether to show or not the grid (third-lines). Defaults to `true`. |
+| `zoomSpeed` | number | | Multiplies the value by which the zoom changes. Defualts to 1. |
 | `onCropChange` | Function | ✓ | Called everytime the crop is changed. Use it to update your `crop` state.|
 | `onZoomChange` | Function |  | Called everytime the zoom is changed. Use it to update your `zoom` state. |
 | [`onCropComplete`](#onCropCompleteProp) | Function |  | Called when the user stops moving the image or stops zooming. It will be passed the corresponding cropped area on the image in percentages and pixels |

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ class App extends React.Component {
 | `maxZoom` | number | | maximum zoom of the image. Defaults to 3. |
 | `cropShape` | 'rect' \| 'round' | | Shape of the crop area. Defaults to 'rect'. |
 | `showGrid` | boolean | | Whether to show or not the grid (third-lines). Defaults to `true`. |
-| `zoomSpeed` | number | | Multiplies the value by which the zoom changes. Defualts to 1. |
+| `zoomSpeed` | number | | Multiplies the value by which the zoom changes. Defaults to 1. |
 | `onCropChange` | Function | ✓ | Called everytime the crop is changed. Use it to update your `crop` state.|
 | `onZoomChange` | Function |  | Called everytime the zoom is changed. Use it to update your `zoom` state. |
 | [`onCropComplete`](#onCropCompleteProp) | Function |  | Called when the user stops moving the image or stops zooming. It will be passed the corresponding cropped area on the image in percentages and pixels |

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -15,6 +15,7 @@ class App extends React.Component {
     aspect: 4 / 3,
     cropShape: 'rect',
     showGrid: true,
+    zoomSpeed: 1,
   }
 
   onCropChange = crop => {
@@ -40,6 +41,7 @@ class App extends React.Component {
             aspect={this.state.aspect}
             cropShape={this.state.cropShape}
             showGrid={this.state.showGrid}
+            zoomSpeed={this.state.zoomSpeed}
             onCropChange={this.onCropChange}
             onCropComplete={this.onCropComplete}
             onZoomChange={this.onZoomChange}

--- a/src/index.js
+++ b/src/index.js
@@ -169,7 +169,7 @@ class Cropper extends React.Component {
   onWheel = e => {
     e.preventDefault()
     const point = Cropper.getMousePoint(e)
-    const newZoom = this.props.zoom - e.deltaY / 200
+    const newZoom = this.props.zoom - (e.deltaY * this.props.zoomSpeed) / 200
     this.setNewZoom(newZoom, point)
   }
 
@@ -300,6 +300,7 @@ Cropper.defaultProps = {
   showGrid: true,
   style: {},
   classes: {},
+  zoomSpeed: 1,
 }
 
 export default Cropper


### PR DESCRIPTION
I added a "zoomSpeed"-prop, which basically just multiplies the deltaY of a mousewheel-turn before adding it to the previous zoom.

closes #20 
