### PR TITLE
Add a crossOrigin pass-through property

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ class App extends React.Component {
 | `onImgError` | Function |  | Called when error occurs while loading an external image |
 | `style` | `{ containerStyle: object, imageStyle: object, cropAreaStyle: object }` |  | Custom styles to be used with the Cropper. Styles passed via the style prop are merged with the defaults. |
 | `classes` | `{ containerClassName: string, imageClassName: string, cropAreaClassName: string }` |  | Custom class names to be used with the Cropper. Classes passed via the classes prop are merged with the defaults. |
+| `crossOrigin` | string |  | Allows setting the crossOrigin attribute on the image. |
 
 <a name="onCropCompleteProp"></a>
 #### onCropComplete(croppedArea, cropperAreaPixels)

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,12 @@
-import { Container, CropArea, Img } from './styles'
+import React from 'react'
 import {
+  getCropSize,
+  restrictPosition,
+  getDistanceBetweenPoints,
   computeCroppedArea,
   getCenter,
-  getCropSize,
-  getDistanceBetweenPoints,
-  restrictPosition,
 } from './helpers'
-
-import React from 'react'
+import { Container, Img, CropArea } from './styles'
 
 const MIN_ZOOM = 1
 const MAX_ZOOM = 3

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,13 @@
-import React from 'react'
+import { Container, CropArea, Img } from './styles'
 import {
-  getCropSize,
-  restrictPosition,
-  getDistanceBetweenPoints,
   computeCroppedArea,
   getCenter,
+  getCropSize,
+  getDistanceBetweenPoints,
+  restrictPosition,
 } from './helpers'
-import { Container, Img, CropArea } from './styles'
+
+import React from 'react'
 
 const MIN_ZOOM = 1
 const MAX_ZOOM = 3
@@ -249,6 +250,7 @@ class Cropper extends React.Component {
       showGrid,
       style: { containerStyle, cropAreaStyle, imageStyle },
       classes: { containerClassName, cropAreaClassName, imageClassName },
+      crossOrigin,
     } = this.props
 
     return (
@@ -272,6 +274,7 @@ class Cropper extends React.Component {
           }}
           imageStyle={imageStyle}
           className={imageClassName}
+          crossOrigin={crossOrigin}
         />
         {this.state.cropSize && (
           <CropArea
@@ -301,6 +304,7 @@ Cropper.defaultProps = {
   style: {},
   classes: {},
   zoomSpeed: 1,
+  crossOrigin: undefined,
 }
 
 export default Cropper


### PR DESCRIPTION
The usage of [crossOrigin](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/crossOrigin) on image tags allows Chrome and Safari to optionally send Origin, Origin + Authentication, or no information (the default) to third-party sites during image loading. This is required when enforcing CORS.