### PR TITLE
Add support for initialCroppedAreaPixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Check out the examples:
 - [Example with image selected by the user](https://codesandbox.io/s/y09komm059)
 - [Example with round crop area and no grid](https://codesandbox.io/s/53w20p2o3n)
 - [Example without restricted position](https://codesandbox.io/s/1rmqky233q)
+- [Example with crop saved/loaded to/from local storage](https://codesandbox.io/s/pmj19vp2yx)
 
 ## Features
 
@@ -102,15 +103,17 @@ class App extends React.Component {
 | `style`                                 | `{ containerStyle: object, imageStyle: object, cropAreaStyle: object }`             |          | Custom styles to be used with the Cropper. Styles passed via the style prop are merged with the defaults.                                                                                                                                                                                                                                 |
 | `classes`                               | `{ containerClassName: string, imageClassName: string, cropAreaClassName: string }` |          | Custom class names to be used with the Cropper. Classes passed via the classes prop are merged with the defaults.                                                                                                                                                                                                                         |
 | `restrictPosition`                      | boolean                                                                             |          | Whether the position of the image should be restricted to the boundaries of the cropper. Useful setting in case of `zoom < 1` or if the cropper should preserve all image content while forcing a specific aspect ratio for image throughout the application. Example: https://codesandbox.io/s/1rmqky233q.                               |
+|                                         |
+| `initialCroppedAreaPixels`              | `{ width: number, height: number, x: number, y: number}`                            |          | Use this to set the initial crop position/zoom of the cropper (for example, when editing a previously cropped image). The value should be the same as the `croppedAreaPixels` passed to [`onCropComplete`](#onCropCompleteProp) Example: https://codesandbox.io/s/pmj19vp2yx.                                                             |
 
 <a name="onCropCompleteProp"></a>
 
-#### onCropComplete(croppedArea, cropperAreaPixels)
+#### onCropComplete(croppedArea, croppedAreaPixels)
 
 This callback is the one you should use to save the cropped area of the image. It's passed 2 arguments:
 
 1. `croppedArea`: coordinates and dimensions of the cropped area in percentage of the image dimension
-1. `cropperAreaPixels`: coordinates and dimensions of the cropped area in pixels.
+1. `croppedAreaPixels`: coordinates and dimensions of the cropped area in pixels.
 
 Both arguments have the following shape:
 

--- a/cypress/integration/basic_spec.js
+++ b/cypress/integration/basic_spec.js
@@ -26,4 +26,9 @@ describe('Basic assertions', function() {
     cy.get('[data-testid=cropper]').should('have.css', 'width', '419px') // 4/3 the height of the image
     cy.get('[data-testid=cropper]').should('have.css', 'height', '314px') // height of the image
   })
+
+  it('should be able to set the crop position/zoom on load', function() {
+    cy.visit('/?setInitialCrop=true')
+    cy.get('img').should('have.css', 'transform', 'matrix(1.9084, 0, 0, 1.9084, -269.274, 80.932)')
+  })
 })

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -47,6 +47,9 @@ class App extends React.Component {
             onCropChange={this.onCropChange}
             onCropComplete={this.onCropComplete}
             onZoomChange={this.onZoomChange}
+            initialCroppedAreaPixels={
+              urlArgs.setInitialCrop && { width: 699, height: 524, x: 875, y: 157 } // used to set the initial crop in e2e test
+            }
           />
         </div>
       </div>

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -124,6 +124,29 @@ function noOp(max, value) {
 }
 
 /**
+ * Compute the crop and zoom from the croppedAreaPixels
+ * @param {{x: number, y: number, width: number, height: number}} croppedAreaPixels
+ * @param {{width: number, height: number, naturalWidth: number, naturelHeight: number}} imageSize width/height of the src image (default is size on the screen, natural is the original size)
+ */
+export function getInitialCropFromCroppedAreaPixels(croppedAreaPixels, imageSize) {
+  const aspect = croppedAreaPixels.width / croppedAreaPixels.height
+  const imageZoom = imageSize.width / imageSize.naturalWidth
+  const isHeightMaxSize = imageSize.naturalWidth >= imageSize.naturalHeight * aspect
+
+  const zoom = isHeightMaxSize
+    ? imageSize.naturalHeight / croppedAreaPixels.height
+    : imageSize.naturalWidth / croppedAreaPixels.width
+
+  const cropZoom = imageZoom * zoom
+
+  const crop = {
+    x: ((imageSize.naturalWidth - croppedAreaPixels.width) / 2 - croppedAreaPixels.x) * cropZoom,
+    y: ((imageSize.naturalHeight - croppedAreaPixels.height) / 2 - croppedAreaPixels.y) * cropZoom,
+  }
+  return { crop, zoom }
+}
+
+/**
  * Return the point that is the center of point a and b
  * @param {{x: number, y: number}} a
  * @param {{x: number, y: number}} b

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -87,48 +87,90 @@ describe('Helpers', () => {
   })
 
   describe('computeCroppedArea', () => {
-    test('should compute the correct areas when the image was not moved', () => {
+    test('should compute the correct areas when the image was not moved and not zoomed', () => {
       const crop = { x: 0, y: 0 }
       const imgSize = { width: 1000, height: 600, naturalWidth: 2000, naturalHeight: 1200 }
-      const cropSize = { width: 500, height: 300 }
+      const cropSize = { width: 1000, height: 600 }
       const aspect = 5 / 3
       const zoom = 1
       const areas = helpers.computeCroppedArea(crop, imgSize, cropSize, aspect, zoom)
-      expect(areas.croppedAreaPercentages).toEqual({ x: 25, y: 25, width: 50, height: 50 })
-      expect(areas.croppedAreaPixels).toEqual({ height: 600, width: 1000, x: 500, y: 300 })
+      expect(areas.croppedAreaPercentages).toEqual({ x: 0, y: 0, width: 100, height: 100 })
+      expect(areas.croppedAreaPixels).toEqual({ height: 1200, width: 2000, x: 0, y: 0 })
     })
 
-    test('should compute the correct areas when the image was moved', () => {
-      const crop = { x: 100, y: 30 }
+    test('should compute the correct areas when the image was moved but not zoomed', () => {
+      const crop = { x: 50, y: 0 }
       const imgSize = { width: 1000, height: 600, naturalWidth: 2000, naturalHeight: 1200 }
-      const cropSize = { width: 500, height: 300 }
-      const aspect = 5 / 3
+      const cropSize = { width: 800, height: 600 }
+      const aspect = 4 / 3
       const zoom = 1
       const areas = helpers.computeCroppedArea(crop, imgSize, cropSize, aspect, zoom)
-      expect(areas.croppedAreaPercentages).toEqual({ height: 50, width: 50, x: 15, y: 20 })
-      expect(areas.croppedAreaPixels).toEqual({ height: 600, width: 1000, x: 300, y: 240 })
+      expect(areas.croppedAreaPercentages).toEqual({ height: 100, width: 80, x: 5, y: 0 })
+      expect(areas.croppedAreaPixels).toEqual({ height: 1200, width: 1600, x: 100, y: 0 })
     })
 
     test('should compute the correct areas when there is a zoom', () => {
       const crop = { x: 0, y: 0 }
       const imgSize = { width: 1000, height: 600, naturalWidth: 2000, naturalHeight: 1200 }
-      const cropSize = { width: 500, height: 300 }
+      const cropSize = { width: 1000, height: 600 }
       const aspect = 5 / 3
       const zoom = 2
       const areas = helpers.computeCroppedArea(crop, imgSize, cropSize, aspect, zoom)
-      expect(areas.croppedAreaPercentages).toEqual({ height: 25, width: 25, x: 37.5, y: 37.5 })
-      expect(areas.croppedAreaPixels).toEqual({ height: 300, width: 500, x: 750, y: 450 })
+      expect(areas.croppedAreaPercentages).toEqual({ height: 50, width: 50, x: 25, y: 25 })
+      expect(areas.croppedAreaPixels).toEqual({ height: 600, width: 1000, x: 500, y: 300 })
     })
 
     test('should not limit the position within image bounds when restrictPosition is false', () => {
       const crop = { x: 1000, y: 600 }
       const imgSize = { width: 1000, height: 600, naturalWidth: 2000, naturalHeight: 1200 }
-      const cropSize = { width: 500, height: 300 }
-      const aspect = 4 / 3
+      const cropSize = { width: 1000, height: 600 }
+      const aspect = 5 / 3
       const zoom = 1
       const areas = helpers.computeCroppedArea(crop, imgSize, cropSize, aspect, zoom, false)
-      expect(areas.croppedAreaPercentages).toEqual({ height: 50, width: 50, x: -75, y: -75 })
-      expect(areas.croppedAreaPixels).toEqual({ height: 600, width: 800, x: -1500, y: -900 })
+      expect(areas.croppedAreaPercentages).toEqual({ height: 100, width: 100, x: -100, y: -100 })
+      expect(areas.croppedAreaPixels).toEqual({ height: 1200, width: 2000, x: -2000, y: -1200 })
+    })
+  })
+
+  describe('getInitialCropFromCroppedAreaPixels', () => {
+    test('should compute the correct crop and zoom when the image was not moved and not zoomed', () => {
+      const croppedAreaPixels = { height: 1200, width: 2000, x: 0, y: 0 }
+      const imgSize = { width: 1000, height: 600, naturalWidth: 2000, naturalHeight: 1200 }
+
+      const { crop, zoom } = helpers.getInitialCropFromCroppedAreaPixels(croppedAreaPixels, imgSize)
+
+      expect(crop).toEqual({ x: 0, y: 0 })
+      expect(zoom).toEqual(1)
+    })
+
+    test('should compute the correct crop and zoom when the image was moved but not zoomed', () => {
+      const croppedAreaPixels = { height: 1200, width: 1600, x: 100, y: 0 }
+      const imgSize = { width: 1000, height: 600, naturalWidth: 2000, naturalHeight: 1200 }
+
+      const { crop, zoom } = helpers.getInitialCropFromCroppedAreaPixels(croppedAreaPixels, imgSize)
+
+      expect(crop).toEqual({ x: 50, y: 0 })
+      expect(zoom).toEqual(1)
+    })
+
+    test('should compute the correct crop and zoom when there is a zoom', () => {
+      const croppedAreaPixels = { height: 600, width: 1000, x: 500, y: 300 }
+      const imgSize = { width: 1000, height: 600, naturalWidth: 2000, naturalHeight: 1200 }
+
+      const { crop, zoom } = helpers.getInitialCropFromCroppedAreaPixels(croppedAreaPixels, imgSize)
+
+      expect(crop).toEqual({ x: 0, y: 0 })
+      expect(zoom).toEqual(2)
+    })
+
+    test('should compute the correct crop and zoom even when restrictPosition was false', () => {
+      const croppedAreaPixels = { height: 1200, width: 2000, x: -2000, y: -1200 }
+      const imgSize = { width: 1000, height: 600, naturalWidth: 2000, naturalHeight: 1200 }
+
+      const { crop, zoom } = helpers.getInitialCropFromCroppedAreaPixels(croppedAreaPixels, imgSize)
+
+      expect(crop).toEqual({ x: 1000, y: 600 })
+      expect(zoom).toEqual(1)
     })
   })
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import {
   getDistanceBetweenPoints,
   computeCroppedArea,
   getCenter,
+  getInitialCropFromCroppedAreaPixels,
 } from './helpers'
 import { Container, Img, CropArea } from './styles'
 
@@ -66,6 +67,24 @@ class Cropper extends React.Component {
   onImgLoad = () => {
     this.computeSizes()
     this.emitCropData()
+    this.setInitialCrop()
+  }
+
+  setInitialCrop = () => {
+    const { initialCroppedAreaPixels } = this.props
+
+    if (!initialCroppedAreaPixels) {
+      return
+    }
+
+    const { x, y, width, height } = initialCroppedAreaPixels
+
+    const { crop, zoom } = getInitialCropFromCroppedAreaPixels(
+      initialCroppedAreaPixels,
+      this.imageSize
+    )
+    this.props.onCropChange(crop)
+    this.props.onZoomChange && this.props.onZoomChange(zoom)
   }
 
   getAspect() {


### PR DESCRIPTION
This enables the cropper to be initialised with a previously saved croppedAreaPixels.

Close #36.

