### PR TITLE
Prevent zooming/moving when picture is loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ cypress/screenshots
 
 docs/.cache
 docs/public
+.idea
+*.iml

--- a/src/index.js
+++ b/src/index.js
@@ -159,6 +159,8 @@ class Cropper extends React.Component {
   }
 
   onDrag = ({ x, y }) => {
+    if (!this.state.cropSize) return
+
     if (this.rafDragTimeout) window.cancelAnimationFrame(this.rafDragTimeout)
 
     this.rafDragTimeout = window.requestAnimationFrame(() => {
@@ -241,6 +243,8 @@ class Cropper extends React.Component {
   }
 
   setNewZoom = (zoom, point) => {
+    if (!this.state.cropSize) return
+
     const zoomPoint = this.getPointOnContainer(point)
     const zoomTarget = this.getPointOnImage(zoomPoint)
     const newZoom = Math.min(this.props.maxZoom, Math.max(zoom, this.props.minZoom))


### PR DESCRIPTION
Here is my PR without all the useless files generated by IntelliJ (it was easier for me to recreate a new one).

The idea is to prevent scrolling/moving when the picture is loading.