### PR TITLE
Constrain image when rotated

### DIFF
--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -43,6 +43,13 @@ class App extends React.Component {
   render() {
     return (
       <div className="App">
+        <input
+          type="range"
+          min={0}
+          max={360}
+          onChange={({ target: { value: rotation } }) => this.setState({ rotation })}
+          style={{ position: 'fixed', zIndex: 9999999 }}
+        />
         <div className="crop-container">
           <Cropper
             image={this.state.imageSrc}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,12 +5,26 @@
  * @param {number} aspect aspect ratio of the crop
  */
 export function getCropSize(imgWidth, imgHeight, aspect, rotation = 0) {
-  const { width } = translateSize(imgWidth, imgHeight, rotation)
+  const { width, height } = translateSize(imgWidth, imgHeight, rotation)
 
   if (imgWidth >= imgHeight * aspect && width > imgHeight * aspect) {
     return {
       width: imgHeight * aspect,
       height: imgHeight,
+    }
+  }
+
+  if (width > imgHeight * aspect) {
+    return {
+      width: imgWidth,
+      height: imgWidth / aspect,
+    }
+  }
+
+  if (width > height * aspect) {
+    return {
+      width: height * aspect,
+      height: height,
     }
   }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -15,8 +15,8 @@ export function getCropSize(imgWidth, imgHeight, aspect, rotation = 0) {
   }
 
   return {
-    width: imgWidth,
-    height: imgWidth / aspect,
+    width: width,
+    height: width / aspect,
   }
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -4,13 +4,16 @@
  * @param {number} imgHeight height of the src image in pixels
  * @param {number} aspect aspect ratio of the crop
  */
-export function getCropSize(imgWidth, imgHeight, aspect) {
-  if (imgWidth >= imgHeight * aspect) {
+export function getCropSize(imgWidth, imgHeight, aspect, rotation = 0) {
+  const { width } = translateSize(imgWidth, imgHeight, rotation)
+
+  if (imgWidth >= imgHeight * aspect && width > imgHeight * aspect) {
     return {
       width: imgHeight * aspect,
       height: imgHeight,
     }
   }
+
   return {
     width: imgWidth,
     height: imgWidth / aspect,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,8 +1,10 @@
 /**
- * Compute the dimension of the crop area based on image size and aspect ratio
+ * Compute the dimension of the crop area based on image size,
+ * aspect ratio and optionally rotatation
  * @param {number} imgWidth width of the src image in pixels
  * @param {number} imgHeight height of the src image in pixels
  * @param {number} aspect aspect ratio of the crop
+ * @param {rotation} rotation rotation in degrees
  */
 export function getCropSize(imgWidth, imgHeight, aspect, rotation = 0) {
   const { width, height } = translateSize(imgWidth, imgHeight, rotation)
@@ -180,13 +182,14 @@ export function getCenter(a, b) {
 
 /**
  *
- * @param {*} x
- * @param {*} y
- * @param {*} xMid
- * @param {*} yMid
- * @param {*} degrees
+ * Returns an x,y point once rotated around xMid,yMid
+ * @param {number} x
+ * @param {number} y
+ * @param {number} xMid
+ * @param {number} yMid
+ * @param {number} degrees
  */
-function rotateAroundMidPoint(x, y, xMid, yMid, degrees) {
+export function rotateAroundMidPoint(x, y, xMid, yMid, degrees) {
   const cos = Math.cos
   const sin = Math.sin
   const radian = (degrees * Math.PI) / 180 // Convert to radians
@@ -200,12 +203,12 @@ function rotateAroundMidPoint(x, y, xMid, yMid, degrees) {
 
 /**
  *
- * @param {*} width
- * @param {*} height
- * @param {*} rotation
- * returns the new bounding area of a rotated rectangle.
+ * Returns the new bounding area of a rotated rectangle.
+ * @param {number} width
+ * @param {number} height
+ * @param {number} rotation
  */
-function translateSize(width, height, rotation) {
+export function translateSize(width, height, rotation) {
   const centerX = width / 2
   const centerY = height / 2
 

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -14,6 +14,14 @@ describe('Helpers', () => {
       const cropSize = helpers.getCropSize(800, 600, 4 / 3)
       expect(cropSize).toEqual({ height: 600, width: 800 })
     })
+    test('when rotated 66 degrees', () => {
+      const cropSize = helpers.getCropSize(1800, 600, 16 / 9, 66)
+      expect(cropSize).toEqual({ height: 600, width: 1066.6666666666665 })
+    })
+    test('when rotated 90 degrees', () => {
+      const cropSize = helpers.getCropSize(1800, 600, 16 / 9, 90)
+      expect(cropSize).toEqual({ height: 337.5, width: 600 })
+    })
   })
 
   describe('restrictPosition', () => {
@@ -189,6 +197,46 @@ describe('Helpers', () => {
     ])('.getCenter(%o, %o)', (a, b, expected) => {
       const center = helpers.getCenter(a, b)
       expect(center).toEqual(expected)
+    })
+  })
+  describe('rotateAroundMidPoint', () => {
+    test('sould rotate correctly around supplied values', () => {
+      expect(helpers.rotateAroundMidPoint(0, 0, 66, 77, 90)).toEqual([143, 11])
+    })
+    test.each([
+      [[0, 0, 66, 77, 9], [12.858023328818689, -9.37667691848084]],
+      [[40, 0, 66, 77, 99], [146.1192983168716, 63.36555695262421]],
+      [[0, 40, 660, 77, 88], [673.9437927760558, -583.8892272105957]],
+      [[70, 40, 9, 737, 240], [-625.1197064377536, 1032.6724503691496]],
+      [[40, 40, 636, 77, 45], [240.72730931671987, -370.5985924910845]],
+    ])('.rotateAroundMidPoint(%s)', (params, expected) => {
+      expect(helpers.rotateAroundMidPoint(...params)).toEqual(expected)
+    })
+  })
+  describe('translateSize', () => {
+    test('should return correct bounding area once rotated', () => {
+      expect(helpers.translateSize(50, 50, 66)).toEqual({
+        height: 66.01410503592005,
+        width: 66.01410503592005,
+      })
+    })
+    test.each([
+      [
+        [780, 2000, 45],
+        {
+          height: 1965.756851698602,
+          width: 1965.756851698602,
+        },
+      ],
+      [
+        [1780, 60, 95],
+        {
+          height: 1778.4559071681665,
+          width: 214.90890397633643,
+        },
+      ],
+    ])('.translateSize(%s)', (params, expected) => {
+      expect(helpers.translateSize(...params)).toEqual(expected)
     })
   })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,10 @@ class Cropper extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.aspect !== this.props.aspect) {
+    if (prevProps.rotation !== this.props.rotation) {
+      this.computeSizes()
+      this.recomputeCropPosition()
+    } else if (prevProps.aspect !== this.props.aspect) {
       this.computeSizes()
     } else if (prevProps.zoom !== this.props.zoom) {
       this.recomputeCropPosition()
@@ -79,8 +82,6 @@ class Cropper extends React.Component {
       return
     }
 
-    const { x, y, width, height } = initialCroppedAreaPixels
-
     const { crop, zoom } = getInitialCropFromCroppedAreaPixels(
       initialCroppedAreaPixels,
       this.imageSize
@@ -107,7 +108,7 @@ class Cropper extends React.Component {
       }
       const cropSize = this.props.cropSize
         ? this.props.cropSize
-        : getCropSize(this.image.width, this.image.height, this.props.aspect)
+        : getCropSize(this.image.width, this.image.height, this.props.aspect, this.props.rotation)
       this.setState({ cropSize }, this.recomputeCropPosition)
     }
     if (this.container) {
@@ -173,7 +174,13 @@ class Cropper extends React.Component {
       }
 
       const newPosition = this.props.restrictPosition
-        ? restrictPosition(requestedPosition, this.imageSize, this.state.cropSize, this.props.zoom)
+        ? restrictPosition(
+            requestedPosition,
+            this.imageSize,
+            this.state.cropSize,
+            this.props.zoom,
+            this.props.rotation
+          )
         : requestedPosition
       this.props.onCropChange(newPosition)
     })
@@ -253,7 +260,13 @@ class Cropper extends React.Component {
       y: zoomTarget.y * newZoom - zoomPoint.y,
     }
     const newPosition = this.props.restrictPosition
-      ? restrictPosition(requestedPosition, this.imageSize, this.state.cropSize, newZoom)
+      ? restrictPosition(
+          requestedPosition,
+          this.imageSize,
+          this.state.cropSize,
+          newZoom,
+          this.props.rotation
+        )
       : requestedPosition
 
     this.props.onCropChange(newPosition)
@@ -265,7 +278,13 @@ class Cropper extends React.Component {
     if (!this.state.cropSize) return
     // this is to ensure the crop is correctly restricted after a zoom back (https://github.com/ricardo-ch/react-easy-crop/issues/6)
     const restrictedPosition = this.props.restrictPosition
-      ? restrictPosition(this.props.crop, this.imageSize, this.state.cropSize, this.props.zoom)
+      ? restrictPosition(
+          this.props.crop,
+          this.imageSize,
+          this.state.cropSize,
+          this.props.zoom,
+          this.props.rotation
+        )
       : this.props.crop
     const { croppedAreaPercentages, croppedAreaPixels } = computeCroppedArea(
       restrictedPosition,
@@ -281,7 +300,13 @@ class Cropper extends React.Component {
 
   recomputeCropPosition = () => {
     const newPosition = this.props.restrictPosition
-      ? restrictPosition(this.props.crop, this.imageSize, this.state.cropSize, this.props.zoom)
+      ? restrictPosition(
+          this.props.crop,
+          this.imageSize,
+          this.state.cropSize,
+          this.props.zoom,
+          this.props.rotation
+        )
       : this.props.crop
     this.props.onCropChange(newPosition)
     this.emitCropData()


### PR DESCRIPTION
Adds support for constraining an image in the crop area when rotated.

See https://github.com/ricardo-ch/react-easy-crop/issues/52
