### PR TITLE
fix(crop size): handle vertical ratio properly

### DIFF
--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -3,24 +3,34 @@ import * as helpers from './helpers'
 describe('Helpers', () => {
   describe('getCropSize', () => {
     test('when media width is higher than the height based on the aspect', () => {
-      const cropSize = helpers.getCropSize(1200, 600, 4 / 3)
+      const cropSize = helpers.getCropSize(1200, 600, 1000, 600, 4 / 3)
       expect(cropSize).toEqual({ height: 600, width: 800 })
     })
     test('when media width is smaller than the height based on the aspect', () => {
-      const cropSize = helpers.getCropSize(600, 1200, 4 / 3)
+      const cropSize = helpers.getCropSize(600, 1200, 1000, 600, 4 / 3)
       expect(cropSize).toEqual({ height: 450, width: 600 })
     })
-    test('when media dimensions exactly match the aspect', () => {
-      const cropSize = helpers.getCropSize(800, 600, 4 / 3)
+    test('when media dimensions exactly match the horizontal aspect', () => {
+      const cropSize = helpers.getCropSize(800, 600, 1000, 600, 4 / 3)
       expect(cropSize).toEqual({ height: 600, width: 800 })
     })
+    test('when media dimensions exactly match the vertical aspect', () => {
+      const cropSize = helpers.getCropSize(600, 800, 1200, 800, 3 / 4)
+      expect(cropSize).toEqual({ height: 800, width: 600 })
+    })
     test('when rotated 66 degrees', () => {
-      const cropSize = helpers.getCropSize(1800, 600, 16 / 9, 66)
-      expect(cropSize).toEqual({ height: 600, width: 1066.6666666666665 })
+      const cropSize = helpers.getCropSize(1000, 524, 1000, 600, 16 / 9, 66)
+      expect(cropSize.width).toBeCloseTo(885, 0)
+      expect(cropSize.height).toBeCloseTo(498, 0)
     })
     test('when rotated 90 degrees', () => {
-      const cropSize = helpers.getCropSize(1800, 600, 16 / 9, 90)
+      const cropSize = helpers.getCropSize(1800, 600, 1000, 600, 16 / 9, 90)
       expect(cropSize).toEqual({ height: 337.5, width: 600 })
+    })
+    test('when rotated 90 degrees and container is vertical', () => {
+      const cropSize = helpers.getCropSize(600, 314, 600, 800, 1000 / 1910, 90)
+      expect(cropSize.width).toBeCloseTo(314, 0)
+      expect(cropSize.height).toBeCloseTo(600, 0)
     })
   })
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,40 +2,30 @@ import { Area, MediaSize, Point, Size } from './types'
 
 /**
  * Compute the dimension of the crop area based on media size,
- * aspect ratio and optionally rotatation
+ * aspect ratio and optionally rotation
  */
 export function getCropSize(
   mediaWidth: number,
   mediaHeight: number,
+  containerWidth: number,
+  containerHeight: number,
   aspect: number,
   rotation = 0
 ): Size {
   const { width, height } = translateSize(mediaWidth, mediaHeight, rotation)
+  const fittingWidth = Math.min(width, containerWidth)
+  const fittingHeight = Math.min(height, containerHeight)
 
-  if (mediaWidth >= mediaHeight * aspect && width > mediaHeight * aspect) {
+  if (fittingWidth > fittingHeight * aspect) {
     return {
-      width: mediaHeight * aspect,
-      height: mediaHeight,
-    }
-  }
-
-  if (width > mediaHeight * aspect) {
-    return {
-      width: mediaWidth,
-      height: mediaWidth / aspect,
-    }
-  }
-
-  if (width > height * aspect) {
-    return {
-      width: height * aspect,
-      height: height,
+      width: fittingHeight * aspect,
+      height: fittingHeight,
     }
   }
 
   return {
-    width: width,
-    height: width / aspect,
+    width: fittingWidth,
+    height: fittingWidth / aspect,
   }
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -205,7 +205,9 @@ class Cropper extends React.Component<Props, State> {
 
   computeSizes = () => {
     const mediaRef = this.imageRef || this.videoRef
-    if (mediaRef) {
+    if (mediaRef && this.containerRef) {
+      this.containerRect = this.containerRef.getBoundingClientRect()
+
       this.mediaSize = {
         width: mediaRef.offsetWidth,
         height: mediaRef.offsetHeight,
@@ -217,13 +219,12 @@ class Cropper extends React.Component<Props, State> {
         : getCropSize(
             mediaRef.offsetWidth,
             mediaRef.offsetHeight,
+            this.containerRect.width,
+            this.containerRect.height,
             this.props.aspect,
             this.props.rotation
           )
       this.setState({ cropSize }, this.recomputeCropPosition)
-    }
-    if (this.containerRef) {
-      this.containerRect = this.containerRef.getBoundingClientRect()
     }
   }
 


### PR DESCRIPTION
Fixes #151 #152

We are now using the container size to compute the crop size. Thanks to this, we can better use to available size for the crop area.

@ajlende Could you please confirm that this fix is working for your use case? Here's your example running the library version from this PR: https://codesandbox.io/s/react-easy-crop-image-aspect-lwpee
You can use this version of the package to test locally: "https://pkg.csb.dev/ricardo-ch/react-easy-crop/commit/4f8563a2/react-easy-crop"
