### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Check out the examples:
 - [Basic example with hooks](https://codesandbox.io/s/v69ly910ql)
 - [Basic example with class](https://codesandbox.io/s/q80jom5ql6)
 - [Example with output of the cropped image](https://codesandbox.io/s/q8q1mnr01w)
-- [Example with image selected by the user (+ auto-rotation for phone pictures)](https://codesandbox.io/s/y09komm059)
+- [Example with image selected by the user (+ auto-rotation for phone pictures)](https://codesandbox.io/s/react-easy-crop-custom-image-demo-forked-08cj4)
 - [Example with round crop area and no grid](https://codesandbox.io/s/53w20p2o3n)
 - [Example without restricted position](https://codesandbox.io/s/1rmqky233q)
 - [Example with crop saved/loaded to/from local storage](https://codesandbox.io/s/pmj19vp2yx)


### PR DESCRIPTION
Added a new codesandbox link to the example of react-easy-crop with the image selected by the user.

After implementing the `react-easy-crop` in a project, I came across a case where we needed to crop a png with _transparent background_ but after the cropping, the transparent background was turning black and the logo title was also written in black.

In canvasUtils, the image creation mimetype is specified as `image/jpeg`, but converting the image to `image/png` clears the issue and converts the background to white by default.

`  return new Promise((resolve) => {
    canvas.toBlob((file) => {
      resolve(URL.createObjectURL(file))
    }, 'image/png')
  })`

