### PR TITLE
Allow multiple sources for video

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,12 @@ import cssStyles from './styles.css'
 
 export type CropperProps = {
   image?: string
-  video?: string
+  video?: string | [
+    {
+      src: string
+      type: string
+    }
+  ]
   transform?: string
   crop: Point
   zoom: number
@@ -538,7 +543,6 @@ class Cropper extends React.Component<CropperProps, State> {
                 mediaClassName
               )}
               {...mediaProps}
-              src={video}
               ref={(el: HTMLVideoElement) => (this.videoRef = el)}
               onLoadedMetadata={this.onMediaLoad}
               style={{
@@ -547,7 +551,9 @@ class Cropper extends React.Component<CropperProps, State> {
                   transform || `translate(${x}px, ${y}px) rotate(${rotation}deg) scale(${zoom})`,
               }}
               controls={false}
-            />
+            >{
+              (Array.isArray(video) ? video : [{src: video}]).map((item: {src: string, format?: string}) => (<source {...item}/>))
+            }</video>
           )
         )}
         {this.state.cropSize && (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -552,7 +552,7 @@ class Cropper extends React.Component<CropperProps, State> {
               }}
               controls={false}
             >{
-              (Array.isArray(video) ? video : [{src: video}]).map((item: {src: string, format?: string}) => (<source {...item}/>))
+              (Array.isArray(video) ? video : [{src: video}] as any[]).map((item: {src: string, type?: string}) => (<source {...item}/>))
             }</video>
           )
         )}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import normalizeWheel from 'normalize-wheel'
-import { Area, MediaSize, Point, Size } from './types'
+import { Area, MediaSize, Point, Size, VideoSrc } from './types'
 import {
   getCropSize,
   restrictPosition,
@@ -15,10 +15,7 @@ import cssStyles from './styles.css'
 
 export type CropperProps = {
   image?: string
-  video?: string | {
-    src: string
-    type: string
-  }[]
+  video?: string | VideoSrc[]
   transform?: string
   crop: Point
   zoom: number
@@ -549,9 +546,11 @@ class Cropper extends React.Component<CropperProps, State> {
                   transform || `translate(${x}px, ${y}px) rotate(${rotation}deg) scale(${zoom})`,
               }}
               controls={false}
-            >{
-              (Array.isArray(video) ? video : [{src: video}] as any[]).map((item: {src: string, type?: string}) => (<source {...item}/>))
-            }</video>
+            >
+              {(Array.isArray(video) ? video : [{ src: video }]).map((item) => (
+                <source {...item} />
+              ))}
+            </video>
           )
         )}
         {this.state.cropSize && (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,12 +15,10 @@ import cssStyles from './styles.css'
 
 export type CropperProps = {
   image?: string
-  video?: string | [
-    {
-      src: string
-      type: string
-    }
-  ]
+  video?: string | {
+    src: string
+    type: string
+  }[]
   transform?: string
   crop: Point
   zoom: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,3 +21,8 @@ export type Area = {
   x: number
   y: number
 }
+
+export type VideoSrc = {
+  src: string
+  type?: string
+}


### PR DESCRIPTION
This PR allows for adding multiple video sources (in optimized formats like WebM) to a video.
With these changes the video prop can be an array with video sources besides a string:
`<Cropper... video={[{
  src: '...',
  type: 'video/webm'
}]} />`

Demo: https://codesandbox.io/s/react-easy-crop-for-videos-forked-fjmj5