### PR TITLE
add alternative way using zoom without material ui slider for codesandbox example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A React component to crop images/videos with easy interactions
 
 Check out the examples:
 
-- [Basic example with hooks](https://codesandbox.io/s/v69ly910ql)
+- [Basic example with hooks](https://codesandbox.io/s/blazing-lake-f8qm2)
 - [Basic example with class](https://codesandbox.io/s/q80jom5ql6)
 - [Basic example in Typescript](https://codesandbox.io/s/react-easy-crop-in-ts-lj1if)
 - [Example with output of the cropped image](https://codesandbox.io/s/q8q1mnr01w)

--- a/docs/src/components/CodeSandboxes/index.tsx
+++ b/docs/src/components/CodeSandboxes/index.tsx
@@ -7,7 +7,7 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import React, { useState } from 'react'
 
 const sandboxes = [
-  { id: 'v69ly910ql', title: 'Basic with hooks' },
+  { id: 'blazing-lake-f8qm2', title: 'Basic with hooks' },
   { id: 'q80jom5ql6', title: 'Basic with class' },
   { id: 'q8q1mnr01w', title: 'With output of the cropped image' },
   { id: 'y09komm059', title: 'With image selected by the user' },
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 const CodeSandboxes: React.FC = props => {
   const classes = useStyles(props)
-  const [sandbox, setSandbox] = useState('v69ly910ql')
+  const [sandbox, setSandbox] = useState('blazing-lake-f8qm2')
   return (
     <div>
       <FormControl variant="filled" className={classes.formControl}>


### PR DESCRIPTION
I dont want add to my project excessive dependencies, so I write my own version for documentation without material ui slider. I tried to reproduce all functionality of material ui slider, but styling effects little bit another, please check and if this on your opinion will be useful for project - merge to library.

